### PR TITLE
fix(bus): 修复getShareFiles并发调用中缺少请求参数的问题

### DIFF
--- a/internal/bus/third_party.go
+++ b/internal/bus/third_party.go
@@ -396,6 +396,9 @@ func (w *busWorker) getShareFiles(ctx context.Context, f *models.VirtualFile) ([
 				subResp, subErr := w.client.ListShareDir(ctx, shareId, client.String(fileId), func(req *client.ListShareFileRequest) {
 					req.PageNum = int(pageNum)
 					req.PageSize = pageSize
+					req.IsFolder, _ = utils.Bool(vv)
+					req.AccessCode = accessCode
+					req.ShareMode = shareMode
 				})
 				if subErr != nil {
 					mu.Lock()


### PR DESCRIPTION
- 在getShareFiles函数的并发处理部分添加缺少的请求参数设置
- 补充IsFolder、AccessCode和ShareMode参数，确保与第一次调用保持一致
- 修复可能导致分享文件列表获取不正确的问题"